### PR TITLE
Improve collaborations card contrast and favicon

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -49,7 +49,8 @@ const App: React.FC = () => {
                     key={company.name}
                     tabIndex={0}
                     title={company.name}
-                    className="p-4 bg-slate-800 rounded-lg flex justify-center items-center h-24 border border-slate-700 shadow-sm transition duration-300 hover:scale-105 hover:bg-slate-700 hover:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400"
+                    aria-label={company.name}
+                    className="p-4 bg-white rounded-lg flex justify-center items-center h-24 border border-slate-200 shadow transition-transform duration-300 hover:scale-105 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-teal-400 focus:ring-offset-2 focus:ring-offset-slate-900"
                   >
                     <img
                       src={company.logoUrl}

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#0f172a"/>
-  <text x="32" y="42" font-size="34" text-anchor="middle" fill="#14b8a6" font-family="Arial, sans-serif">Z</text>
+  <rect width="64" height="64" rx="8" fill="#14b8a6"/>
+  <path d="M20 16h24L20 48h24" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>


### PR DESCRIPTION
## Summary
- enhance contrast and accessibility of Collaborations company cards
- replace favicon with cleaner SVG for Chrome tabs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd2761627083249989dbc1607a7261