### PR TITLE
feat: refresh favicon with 3d ZP monogram

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#14b8a6"/>
-  <path d="M20 16h24L20 48h24" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">ZP monogram favicon</title>
+  <desc id="desc">Chrome-style three-dimensional monogram of the letters Z and P on a radiant teal background.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f2937"/>
+      <stop offset="50%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#14b8a6"/>
+    </linearGradient>
+    <linearGradient id="gloss" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.55)"/>
+      <stop offset="35%" stop-color="rgba(255,255,255,0.0)"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)"/>
+  <path d="M8 16c0-4.418 3.582-8 8-8h32c4.418 0 8 3.582 8 8v32c0 4.418-3.582 8-8 8H16c-4.418 0-8-3.582-8-8z" fill="url(#gloss)"/>
+  <g fill-rule="evenodd">
+    <path d="M18 22h24l-4.8 6.4H23.2L45 46H19.4l4.7-6.2h14.2L18 22z" fill="#38bdf8" opacity="0.7" transform="translate(2 2)"/>
+    <path d="M18 22h24l-4.8 6.4H23.2L45 46H19.4l4.7-6.2h14.2L18 22z" fill="#f8fafc"/>
+    <path d="M32 18h14c7 0 12 4.4 12 10.2 0 5.9-4.9 10.4-12 10.4h-9.2V46h-6.8V18zm6.8 6.2v8h7.2c2.4 0 4.2-1.7 4.2-4s-1.8-4-4.2-4z" fill="#38bdf8" opacity="0.7" transform="translate(2 2)"/>
+    <path d="M32 18h14c7 0 12 4.4 12 10.2 0 5.9-4.9 10.4-12 10.4h-9.2V46h-6.8V18zm6.8 6.2v8h7.2c2.4 0 4.2-1.7 4.2-4s-1.8-4-4.2-4z" fill="#f8fafc"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- redesign the favicon as a chrome-inspired 3D ZP monogram
- add gradient background and glossy highlight for added depth
- layer offset shapes to give the letters dimensional shading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce5a9a5600832495a63f573a8c5ce5