### PR TITLE
Add topology snapshot for Project18 deployment bundles

### DIFF
--- a/components/ProjectModal.tsx
+++ b/components/ProjectModal.tsx
@@ -122,6 +122,15 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({ project, onClose }) 
             </div>
           </div>
 
+          {project.topologySnapshot && (
+            <div className="mt-6">
+              <h3 className="text-lg font-semibold text-slate-200">ASCII Topology Snapshot</h3>
+              <pre className="mt-2 whitespace-pre-wrap rounded-lg border border-slate-700 bg-slate-900/60 p-4 font-mono text-sm text-slate-300 overflow-x-auto">
+                {project.topologySnapshot}
+              </pre>
+            </div>
+          )}
+
           {project.links.length > 0 && (
             <div className="mt-6">
               <h3 className="text-lg font-semibold text-slate-200">Links</h3>

--- a/constants.ts
+++ b/constants.ts
@@ -341,15 +341,47 @@ export const PROJECTS: Project[] = [
     id: 23,
     title: "Project18 Automation Stack",
     description: "Gives B2B teams a ready-to-launch Telegram bot, Mini App, and lead funnel powered by agentic workflows.",
-    longDescription: "Project18 delivers a full automation stack that launches a Telegram bot, companion Mini App, and AI-routed lead funnel in minutes. Under the hood it unifies GPT-5 orchestration, reusable MCP tools, multi-tenant data stores, and telemetry guardrails to keep every customer touchpoint observable and adaptive.",
+    longDescription: "Project18 delivers a full automation stack that launches a Telegram bot, companion Mini App, and AI-routed lead funnel in minutes. Under the hood it unifies GPT-5 orchestration, reusable MCP tools, multi-tenant data stores, and telemetry guardrails to keep every customer touchpoint observable and adaptive. The deployment bundles cover every layer from client experiences to observability, so teams can ship confidently.",
     keyFeatures: [
       "Instant Telegram bot & Mini App deployment",
       "Agentic workflows nurturing inbound leads",
-      "Unified telemetry and safety guardrails"
+      "Unified telemetry and safety guardrails",
+      "Deployment bundles covering clients, delivery, orchestration, data, integration, and operations"
     ],
     techStack: ["GPT-5 orchestration", "MCP tools", "Multi-tenant data stores", "Telemetry guardrails"],
     links: [{ text: "Live Demo", url: "https://project018-mcp-1095464065298.us-east1.run.app/" }],
     images: [],
-    thumbnail: "https://placehold.co/600x400?text=Project18"
+    thumbnail: "https://placehold.co/600x400?text=Project18",
+    topologySnapshot: `Clients Layer
+  - Telegram Bot
+  - Telegram Mini App
+  - Landing + Console
+        |
+        v
+Edge & Delivery Layer (CDN / Edge Functions)
+        |
+        v
+Gateway & Policy Layer (API Gateway + Auth)
+        |
+        v
++-----------------------------------------+
+|           Orchestration Layer           |
+| Router -> Persona -> Workflow -> ToolBus|
+|                   |                     |
+|                   v                     |
+|         MCP Tool Mesh Bridge            |
++-----------------------------------------+
+        |
+        v
+Data & Knowledge Layer
+  - Tenant DB / Secrets
+  - Vector Store / Memories
+  - Object & Telemetry Stores
+        |
+        v
+Integration Layer (Connectors via MCP)
+        |
+        v
+Operations Layer (Console, Alerts, Runbooks)`
   },
 ];

--- a/types.ts
+++ b/types.ts
@@ -20,6 +20,7 @@ export interface Project {
   links: ProjectLink[];
   images: ProjectImage[];
   thumbnail: string;
+  topologySnapshot?: string;
 }
 
 export interface Company {


### PR DESCRIPTION
## Summary
- add optional topology snapshot field for portfolio projects and render it in the project modal
- enrich Project18 copy with deployment bundle messaging and embed the ASCII topology snapshot provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce5cbf92b88324a048500e9aa834e5